### PR TITLE
Fixed a `table expected, got nil` error

### DIFF
--- a/dtile/dtile.lua
+++ b/dtile/dtile.lua
@@ -101,6 +101,7 @@ local function configure_animation_groups_instances()
 	for i = 1, #dtile.tilemap_layers do
 		dtile.tilemap_grid[dtile.tilemap_layers[i]] = {}
 		for j = dtile.tilemap_start_y, dtile.tilemap_end_y do
+			dtile.tilemap_grid[dtile.tilemap_layers[i]][j] = {}
 			table.insert(dtile.tilemap_grid[dtile.tilemap_layers[i]], {})
 			for k = dtile.tilemap_start_x, dtile.tilemap_end_x do
 				local tile_id = tilemap.get_tile(dtile.tilemap_url, dtile.tilemap_layers[i], k, j)


### PR DESCRIPTION
The `table.insert(dtile.tilemap_grid[dtile.tilemap_layers[i]][j], tile_id)` line can spit out `bad argument #1 to 'insert' (table expected, got nil)` error. I'm not 100% sure but I think it happens when the `tilemap_start_y` is anything but 1.